### PR TITLE
Add API resource

### DIFF
--- a/ActivityLogPlugin.php
+++ b/ActivityLogPlugin.php
@@ -24,6 +24,7 @@ class ActivityLogPlugin extends Omeka_Plugin_AbstractPlugin
 
     protected $_filters = [
         'admin_navigation_main',
+        'api_resources',
         'activity_log_event_messages',
     ];
 
@@ -199,6 +200,16 @@ class ActivityLogPlugin extends Omeka_Plugin_AbstractPlugin
             'resource' => 'ActivityLog_Events',
         ];
         return $nav;
+    }
+
+    public function filterApiResources($apiResources)
+    {
+        $apiResources['activity_log_events'] = [
+            'record_type' => 'ActivityLogEvent',
+            'actions' => ['get', 'index'],
+            'index_acl_resource' => 'ActivityLog_Events',
+        ];
+        return $apiResources;
     }
 
     public function filterActivityLogEventMessages($messages, $args)

--- a/models/Api/ActivityLogEvent.php
+++ b/models/Api/ActivityLogEvent.php
@@ -1,0 +1,13 @@
+<?php
+class Api_ActivityLogEvent extends Omeka_Record_Api_AbstractRecordAdapter implements Zend_Acl_Resource_Interface
+{
+    public function getResourceId()
+    {
+        return 'ActivityLog_Events';
+    }
+
+    public function getRepresentation(Omeka_Record_AbstractRecord $event)
+    {
+        return json_decode(json_encode($event), true);
+    }
+}


### PR DESCRIPTION
Requires the `index_acl_resource` route option in core to restrict API access. Merge this PR once it is added and released.

https://github.com/omeka/Omeka/pull/1086/changes